### PR TITLE
Implement search endpoint for posts (fixes #8)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -54,6 +54,7 @@ func NewApi(
 	v0.Handle("PATCH", "/posts/{postId}", HandleModifyPost)
 	v0.Handle("DELETE", "/posts/{postId}", HandleDeletePost)
 	v0.Handle("POST", "/categories", HandleCreateCategory)
+	v0.Handle("GET", "/search", HandleSearch)
 
 	// openapi
 	buildOpenApi(b)

--- a/api/handle_search.go
+++ b/api/handle_search.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func HandleSearch(w http.ResponseWriter, r *http.Request) ([]Post, error) {
+	ctx := r.Context()
+
+	p := GetPostPersistence(ctx)
+
+	posts, err := p.List(ctx)
+	if err != nil {
+		log.Println("p.List:", err)
+		return nil, ErrorPersistenceRead
+	}
+
+	queryParams := r.URL.Query()
+	q := queryParams.Get("q")
+	if q == "" {
+		http.Error(w, "q is required", http.StatusBadRequest)
+		return nil, fmt.Errorf("q is required")
+	}
+
+	qLower := strings.ToLower(q)
+
+	var sPosts []Post
+
+	for _, post := range posts {
+		titleLower := strings.ToLower(post.Item.Title)
+		bodyLower := strings.ToLower(post.Item.Body)
+		if strings.Contains(titleLower, qLower) || strings.Contains(bodyLower, qLower) {
+			sPosts = append(sPosts, post.Item)
+		}
+	}
+
+	return sPosts, nil
+
+}


### PR DESCRIPTION
- Nuevo endpoint: GET /v0/search?q=palabra
- Permite buscar artículos en memoria por título o contenido