### PR TITLE
Add pagination support for posts list (fixes #13)

### DIFF
--- a/statics/www/admin/posts/index.html
+++ b/statics/www/admin/posts/index.html
@@ -89,6 +89,19 @@
                   class="input input-bordered"
                 />
               </div>
+              <div>
+                <div class="flex justify-center items-center gap-3 mb-6">
+                  <label for="post-limit" class="font-medium">Mostrar</label>
+                  <select id="post-limit" class="select select-sm select-primary w-28">
+                    <option value="5">5</option>
+                    <option value="10" selected>10</option>
+                    <option value="20">20</option>
+                    <option value="50">50</option>
+                    <option value="100">100</option>
+                  </select>
+                  <span class="text-sm text-gray-500">posts por página</span>
+                </div>
+              </div>
             </div>
             <table class="table">
               <thead>
@@ -106,6 +119,19 @@
             </table>
           </div>
         </section>
+        <div class="flex justify-center mt-8 space-x-2" id="pagination">
+          <!-- Prev -->
+          <button id="prev-btn" class="btn btn-sm">« Prev</button>
+
+
+          <!-- Pages -->
+          <div id="pagination-pages" class="flex space-x-1"></div>
+
+
+          <!-- Next -->
+          <button id="next-btn" class="btn btn-sm">Next »</button>
+
+        </div>
       </main>
     </div>
 

--- a/statics/www/admin/posts/js/post-service.js
+++ b/statics/www/admin/posts/js/post-service.js
@@ -16,8 +16,14 @@ export class PostService {
    * Retrieves all posts.
    * @returns {Promise<Array>} A promise that resolves to an array of posts.
    */
-  async listPosts() {
-    const response = await fetch(this.baseUrl, { headers: this.headers });
+  async listPosts(params = {}) {
+    const url = new URL(this.baseUrl, window.location.origin);
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        url.searchParams.append(key, value);
+      }
+    });
+    const response = await fetch(url, { headers: this.headers });
     return await response.json();
   }
 

--- a/statics/www/index.gohtml
+++ b/statics/www/index.gohtml
@@ -85,6 +85,17 @@
         </div>
       </div>
       {{ end }}
+      <div class="flex justify-center items-center gap-3 mb-6">
+        <label for="post-limit" class="font-medium">Mostrar</label>
+        <select id="post-limit" class="select select-sm select-primary w-28">
+          <option value="5" {{ if eq .Limit 5 }}selected{{ end }}>5</option>
+          <option value="10" {{ if eq .Limit 10 }}selected{{ end }}>10</option>
+          <option value="20" {{ if eq .Limit 20 }}selected{{ end }}>20</option>
+          <option value="50" {{ if eq .Limit 50 }}selected{{ end }}>50</option>
+          <option value="100" {{ if eq .Limit 100 }}selected{{ end }}>100</option>
+        </select>
+        <span class="text-sm text-gray-500">posts por página</span>
+      </div>
       <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
         {{ range .Posts }}
         <div class="card bg-base-100 shadow-xl">
@@ -132,6 +143,35 @@
           {{ end }}
         </div>
         {{ end }}
+      </div>
+      <div class="flex justify-center mt-8 space-x-2">
+        {{ $limit := .Limit }}
+        {{ $skip := .Skip }}
+        {{ $total := .TotalPosts }}
+        {{ $totalPages := (add (div (sub $total 1) $limit) 1) }}
+        {{ $currentPage := (div $skip $limit) | add 1 }}
+
+        <!-- Prev -->
+          <a class="btn btn-sm {{ if eq $currentPage 1 }}btn-disabled{{ end }}"
+             href="/?limit={{$limit}}&skip={{mul (sub $currentPage 2) $limit}}">
+            « Prev
+          </a>
+
+        <!-- Pages -->
+        {{ range $i := until $totalPages }}
+          {{ $page := add $i 1 }}
+          <a class="btn btn-sm {{ if eq $page $currentPage }}btn-primary{{ end }}"
+             href="/?limit={{$limit}}&skip={{mul (sub $page 1) $limit}}">
+            {{ $page }}
+          </a>
+        {{ end }}
+
+        <!-- Next -->
+          <a class="btn btn-sm {{ if eq $currentPage $totalPages }}btn-disabled{{ end }}"
+
+             href="/?limit={{$limit}}&skip={{mul $currentPage $limit}}">
+            Next »
+          </a>
       </div>
     </div>
 

--- a/statics/www/js/index.js
+++ b/statics/www/js/index.js
@@ -6,6 +6,14 @@ const avatarBtn = document.getElementById("auth_avatar");
 const avatarImg = document.getElementById("auth_avatar_image");
 const versionContainer = document.getElementById("version");
 
+document.getElementById("post-limit").addEventListener("change", function() {
+    const limit = this.value;
+    const url = new URL(window.location.href)
+    url.searchParams.set("limit", limit);
+    url.searchParams.set("skip", 0);
+    window.location.href = url.toString();
+
+})
 fetch("/version")
   .then((req) => req.text())
   .then((version) => {


### PR DESCRIPTION
Este PR añade paginación a la lista de posts en la interfaz administrativa y en la página principal.

- Se agregó un selector de límite con opciones: 5, 10, 20, 50 y 100 posts por página.
- Modificación en `HandleListPosts` para soportar la paginación en el backend.
- Actualización en `HandleRenderHome` para soportar paginación en la página principal.
- Cambios en las vistas: `statics/www/admin/posts` y `statics/www/index.gohtml`.

Fixes #13